### PR TITLE
Modified to download NuGet.exe on build in case it is mising.

### DIFF
--- a/.nuget/NuGet.targets
+++ b/.nuget/NuGet.targets
@@ -13,7 +13,7 @@
         <RequireRestoreConsent Condition=" '$(RequireRestoreConsent)' != 'false' ">true</RequireRestoreConsent>
 
         <!-- Download NuGet.exe if it does not already exist -->
-        <DownloadNuGetExe Condition=" '$(DownloadNuGetExe)' == '' ">false</DownloadNuGetExe>
+        <DownloadNuGetExe Condition=" '$(DownloadNuGetExe)' == '' ">true</DownloadNuGetExe>
     </PropertyGroup>
 
     <ItemGroup Condition=" '$(PackageSources)' == '' ">


### PR DESCRIPTION
Gitignore is not uploading the Exe file, NuGet crashes if the file is not there, so now it will download the file before calling NuGet.
